### PR TITLE
Made it so Init view is hidden after loads combined data

### DIFF
--- a/src/controllers/initial_controller.py
+++ b/src/controllers/initial_controller.py
@@ -14,11 +14,13 @@ class InitialController:
         self.root = root
         self.model = model 
         self.main_controller = main_controller
+        self.view = None
         logging.info("InitialController initialized.")
 
     def show_initial_view(self):
         view = InitialView(self.root, self).create_widgets()
         self.main_controller.add_tab(view, "Data Loader")
+        self.view = view
         return view
 
     # 1. Reading Excel Files
@@ -44,9 +46,11 @@ class InitialController:
         if self.model.combine_data():
             logging.info("Data combined successfully.")
             self.load_combined_data()
+            self.main_controller.remove_tab(self.view)
 
 
     def load_combined_data(self):
         if self.model.load_combined_data():
             logging.info("Combined data loaded successfully.")
             self.main_controller.show_combined_data()
+            self.main_controller.remove_tab(self.view)


### PR DESCRIPTION
just needed to add a internal reference to it's view so It could call it on remove tab. This is a quickfix I know we considered the idea of having multiple combined views operational at once, but until we have time to explore that further this will keep users from causing unintentional behavior.