### PR TITLE
Fixed Nans & duplicate data not showing

### DIFF
--- a/src/controllers/combined_data_controller.py
+++ b/src/controllers/combined_data_controller.py
@@ -26,7 +26,9 @@ class CombinedDataController:
             logging.info(f"Combined data has {len(self.model.combined_data)} records.")
             # Calculate unmatched count
             unmatched_count = len(self.model.unmatched_data) if self.model.unmatched_data is not None else 0
-            self.view = CombinedDataView(self.root, self, self.model.combined_data, unmatched_count=unmatched_count)
+            duplicate_count = len(self.model.duplicate_data) if self.model.duplicate_data is not None else 0
+            print (f"Unmatched Count: {unmatched_count}, Duplicate Count: {duplicate_count}")
+            self.view = CombinedDataView(self.root, self, self.model.combined_data, unmatched_count, duplicate_count)
             frame = self.view.create_widgets()
             self.main_controller.add_tab(frame, "Combined Data")
         else:
@@ -64,10 +66,13 @@ class CombinedDataController:
         if self.view:
             try:
                 # Reload fresh data from Excel
-                fresh_data = pd.read_excel('combined_matched_data.xlsx')
+                fresh_data = self.model.updated_data()
+                
+                if fresh_data is None or fresh_data.empty:
+                    messagebox.showerror("Error", "No fresh data available to refresh the view.")
+                    return
                 
                 # Update all data sources
-                self.model.combined_data = fresh_data
                 self.view.combined_data = fresh_data
                 self.view.filtered_data = fresh_data
                 

--- a/src/models/data_model.py
+++ b/src/models/data_model.py
@@ -149,8 +149,9 @@ class DataModel:
                 if col in combined.columns:
                     combined[col] = combined[col].astype(str).str.capitalize()
 
-            if 'Assigned_Nurse' not in combined.columns:
-                combined['Assigned_Nurse'] = None
+             # Check and set 'Assigned_Nurse' column to None if it has no value
+            if 'Assigned_Nurse' in combined.columns:
+                combined['Assigned_Nurse'] = combined['Assigned_Nurse'].fillna('None')
 
             combined.to_excel('combined_matched_data.xlsx', index=False)
             self.combined_data = combined
@@ -174,11 +175,9 @@ class DataModel:
 
             df = pd.read_excel(path)
 
-            # Fix data type issues
-            df = df.astype(str).fillna("None")
-
-            if 'Assigned_Nurse' not in df.columns:
-                df['Assigned_Nurse'] = None
+            # Check and set 'Assigned_Nurse' column to None if it has no value
+            if 'Assigned_Nurse' in df.columns:
+                df['Assigned_Nurse'] = df['Assigned_Nurse'].fillna('None')
 
             self.combined_data = df
 
@@ -187,6 +186,12 @@ class DataModel:
                 self.unmatched_data = pd.read_excel(unmatched_path)
             else:
                 self.unmatched_data = pd.DataFrame()
+
+            duplicate_path = 'duplicate_names.xlsx'
+            if os.path.exists(duplicate_path):
+                self.duplicate_data = pd.read_excel(duplicate_path)
+            else:
+                self.duplicate_data = pd.DataFrame()
 
             return True
 
@@ -253,3 +258,40 @@ class DataModel:
         if row.empty:
             return None
         return row.iloc[0]
+    
+    def updated_data(self):
+        """
+        Return the current state of the combined data and unmatched data DataFrames.
+        """
+        path = 'combined_matched_data.xlsx'
+        if not os.path.exists(path):
+            messagebox.showerror("Error", "No combined data file found. Cannot Refresh")
+            return False
+        
+        try:
+
+            df = pd.read_excel(path)
+
+            # Check and set 'Assigned_Nurse' column to None if it has no value
+            if 'Assigned_Nurse' in df.columns:
+                df['Assigned_Nurse'] = df['Assigned_Nurse'].fillna('None')
+
+            self.combined_data = df
+
+            unmatched_path = 'unmatched_data.xlsx'
+            if os.path.exists(unmatched_path):
+                self.unmatched_data = pd.read_excel(unmatched_path)
+            else:
+                self.unmatched_data = pd.DataFrame()
+
+            duplicate_path = 'duplicate_names.xlsx'
+            if os.path.exists(duplicate_path):
+                self.duplicate_data = pd.read_excel(duplicate_path)
+            else:
+                self.duplicate_data = pd.DataFrame()
+
+            return self.combined_data
+        
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to refresh combined data: {e}")
+            return None

--- a/src/views/combined_data_view.py
+++ b/src/views/combined_data_view.py
@@ -9,7 +9,7 @@ class CombinedDataView:
     plus search, sort by DOB, nurse stats, batch assign, unmatched, etc.
     """
 
-    def __init__(self, root, controller, combined_data, unmatched_count=0):
+    def __init__(self, root, controller, combined_data, unmatched_count=0, duplicate_count=0):
         self.root = root
         self.controller = controller
 
@@ -18,6 +18,7 @@ class CombinedDataView:
 
         self.sort_ascending = True
         self.unmatched_count = unmatched_count
+        self.duplicate_count = duplicate_count
 
         logging.info("CombinedDataView initialized.")
 
@@ -104,7 +105,7 @@ class CombinedDataView:
             count_label.place(relx=1.0, rely=0.0, anchor="ne")
 
         # If there are duplicate rows, show a button with a blue badge
-        if self.controller.model.duplicate_data is not None and not self.controller.model.duplicate_data.empty:
+        if self.duplicate_count > 0:
             duplicate_button = tk.Button(bottom_frame, text="View Duplicate Data", command=self.controller.view_duplicate_data)
             duplicate_button.pack(side=tk.LEFT, padx=10)
             # Badge


### PR DESCRIPTION
Fixed nans by double checking to fill empty spots when data is both loaded and updated. Then fixed duplicate data button not showing when load from file because we were just not including a check for saved duplicate names.